### PR TITLE
Add support for Splatoon BYAML files

### DIFF
--- a/src/Syroot.NintenTools/Byaml/ByamlFile.cs
+++ b/src/Syroot.NintenTools/Byaml/ByamlFile.cs
@@ -212,7 +212,7 @@ namespace Syroot.NintenTools.Byaml
         private dynamic Read(Stream stream)
         {
             // Open a reader on the given stream.
-            using (BinaryDataReader reader = new BinaryDataReader(stream, Encoding.ASCII, true))
+            using (BinaryDataReader reader = new BinaryDataReader(stream, Encoding.UTF8, true))
             {
                 reader.ByteOrder = ByteOrder.BigEndian;
 
@@ -445,7 +445,7 @@ namespace Syroot.NintenTools.Byaml
             _stringArray.Sort(StringComparer.Ordinal);
 
             // Open a writer on the given stream.
-            using (BinaryDataWriter writer = new BinaryDataWriter(stream, Encoding.ASCII, true))
+            using (BinaryDataWriter writer = new BinaryDataWriter(stream, Encoding.UTF8, true))
             {
                 writer.ByteOrder = ByteOrder.BigEndian;
 

--- a/src/Syroot.NintenTools/Byaml/ByamlNodeType.cs
+++ b/src/Syroot.NintenTools/Byaml/ByamlNodeType.cs
@@ -48,6 +48,11 @@
         /// <summary>
         /// The node represents a <see cref="float"/>.
         /// </summary>
-        Float = 0xD2
+        Float = 0xD2,
+
+        /// <summary>
+        /// The node represents null.
+        /// </summary>
+        Null = 0xFF
     }
 }


### PR DESCRIPTION
This adds support for Null nodes and UTF-8 text (found in Splatfest BYAMLs). It also adds some special logic specifically for saving and loading Splatoon BYAML files as they don't include any path array offsets whatsoever.